### PR TITLE
Do not put response bodies

### DIFF
--- a/lib/fund_america/api.rb
+++ b/lib/fund_america/api.rb
@@ -10,7 +10,6 @@ module FundAmerica
         response = HTTParty.send(method, uri, options)
         parsed_response = JSON.parse(response.body)
         if response.code.to_i == 200
-          puts parsed_response.inspect
           # Returns parsed_response - a hash of response body
           # if response is successful
           parsed_response


### PR DESCRIPTION
This change ensures that response bodies are not erroneously logged to the console. By logging responses this gem could inadvertently expose highly sensitive information, i.e. a user's SSN, in plaintext. 
