### PR TITLE
Make tests pass, make it possible to run tests without changing code, add 422 response body to error message.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,14 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Running tests
+
+To the run tests get a sandbox key from `https://sandbox.fundamerica.com/accounts/<your-account>/api_keys` then run:
+
+```console
+$ env FUND_AMERICA_SANDBOX_KEY='<YOUR-SANDBOX-KEY>' rspec
+```
+
 ## Contributing
 
 1. Fork it ( https://github.com/rubyeffect/fund_america/fork )

--- a/lib/fund_america.rb
+++ b/lib/fund_america.rb
@@ -6,11 +6,7 @@ module FundAmerica
   class << self
     # Returns API key or raises exception
     def api_key
-      # TODO - Uncomment below line for production
       defined? @api_key and @api_key or raise "FundAmerica.api_key not configured"
-
-      # Sandbox test API key is used for development
-      # defined? @api_key and @api_key or @api_key = test_api_key
     end
     attr_writer :api_key
 
@@ -45,11 +41,5 @@ module FundAmerica
         }
       }
     end
-
-    # Sandbox API key - Only for development purpose
-    # TODO - Remove this method for production
-    # def test_api_key
-    #  "sandbox-key-here"
-    # end
   end
 end

--- a/lib/fund_america/error.rb
+++ b/lib/fund_america/error.rb
@@ -5,12 +5,12 @@ module FundAmerica
     # Contructor method to take response code and parsed_response
     # and give object methods in rescue - e.message and e.parsed_response
     def initialize(parsed_response, code)
-      super(FundAmerica::Error.error_message(code))
+      super(FundAmerica::Error.error_message(code, parsed_response))
       @parsed_response = parsed_response
     end
 
     # Method to return error message based on the response code
-    def self.error_message(code)
+    def self.error_message(code, parsed_response)
       case code
       when 401 then
         'Authentication error. Your API key is incorrect'
@@ -19,7 +19,7 @@ module FundAmerica
       when 404 then
         'Resource was not found'
       when 422 then
-        'This usually means you are missing or have supplied invalid parameters for a request'
+        "This usually means you are missing or have supplied invalid parameters for a request: #{parsed_response}"
       when 500 then
         "Internal server error. Something went wrong. This is a bug. Please report it to support immediately"
       else

--- a/spec/fund_america/cancel_offering_request_spec.rb
+++ b/spec/fund_america/cancel_offering_request_spec.rb
@@ -121,7 +121,7 @@ describe FundAmerica::CancelOfferingRequest do
       end
 
       it 'must have the updated status' do
-        expect(@updated_details['status']).to eq('confirmed')
+        expect(@updated_details['status']).to eq('accepted')
       end
     end
   end

--- a/spec/fund_america/entity_relationship_spec.rb
+++ b/spec/fund_america/entity_relationship_spec.rb
@@ -57,29 +57,30 @@ describe FundAmerica::EntityRelationship do
       options_one = {
         :city => 'Las Vegas',
         :country => 'US',
-        :email => "test#{t}@test.com",
-        :name => "Test U#{t}",
+        :email => "test#{t_one}@test.com",
+        :name => "Test C#{t_one}",
         :phone => '12025551212',
         :postal_code => '89123',
         :region => 'NV',
         :street_address_1 => '123 street',
         :tax_id_number => '123123123',
-        :type => "person",
-        :date_of_birth => '1980-01-01'
+        :type => "company",
+        :region_formed_in => 'NV',
+        :contact_name => "Test User"
       }
       @entity_one = FundAmerica::Entity.create(options_one)
       t_two = Time.now.to_i
       options_two = {
         :city => 'Las Vegas',
         :country => 'US',
-        :email => "test#{t}@test.com",
-        :name => "Test U#{t}",
+        :email => "test#{t_two}@test.com",
+        :name => "Test U#{t_two}",
+        :contact_name => "Test User",
         :phone => '12025551212',
         :postal_code => '89123',
         :region => 'NV',
         :street_address_1 => '123 street',
         :tax_id_number => '123123123',
-        :type => "person",
         :date_of_birth => '1980-01-01'
       }
       @entity_two = FundAmerica::Entity.create(options_two)

--- a/spec/fund_america/entity_spec.rb
+++ b/spec/fund_america/entity_spec.rb
@@ -100,8 +100,12 @@ describe FundAmerica::Entity do
           expect(@entity_details).not_to be nil
         end
 
+        it 'must have entity as person' do
+          expect(@entity_details['type']).to eq('person')
+        end
+
         it 'must be an entity object' do
-          expect(@entity_details['object']).to eq('person')
+          expect(@entity_details['object']).to eq('entity')
         end
 
         it 'must return entity details for the given entity id' do
@@ -268,8 +272,12 @@ describe FundAmerica::Entity do
           expect(@entity_details).not_to be nil
         end
 
+        it 'must have a type of company' do
+          expect(@entity_details['type']).to eq('company')
+        end
+
         it 'must be an entity object' do
-          expect(@entity_details['object']).to eq('company')
+          expect(@entity_details['object']).to eq('entity')
         end
 
         it 'must return entity details for the given entity id' do

--- a/spec/fund_america/error_spec.rb
+++ b/spec/fund_america/error_spec.rb
@@ -6,19 +6,19 @@ describe FundAmerica::Error do
       @message_401 = 'Authentication error. Your API key is incorrect'
       @message_403 = "Not authorized. You don't have permission to take action on a particular resource. It may not be owned by your account or it may be in a state where you action cannot be taken (such as attempting to cancel an invested investment)"
       @message_404 = 'Resource was not found'
-      @message_422 = 'This usually means you are missing or have supplied invalid parameters for a request'
+      @message_422 = 'This usually means you are missing or have supplied invalid parameters for a request: {}'
       @message_500 = "Internal server error. Something went wrong. This is a bug. Please report it to support immediately"
       @message_other = 'An error occured. Please check parsed_response for details'
     end
 
     it 'must have an error message' do
-      response = FundAmerica::Error.error_message(422)
+      response = FundAmerica::Error.error_message(422, {})
       expect(response).not_to be nil
     end
 
     context '401 code' do
       before(:all) do
-        @response = FundAmerica::Error.error_message(401)
+        @response = FundAmerica::Error.error_message(401, {})
       end
 
       it 'must match 401 error message when code is 401' do
@@ -32,7 +32,7 @@ describe FundAmerica::Error do
 
     context '403 code' do
       before(:all) do
-        @response = FundAmerica::Error.error_message(403)
+        @response = FundAmerica::Error.error_message(403, {})
       end
 
       it 'must match 403 error message when code is 403' do
@@ -46,7 +46,7 @@ describe FundAmerica::Error do
 
     context '404 code' do
       before(:all) do
-        @response = FundAmerica::Error.error_message(404)
+        @response = FundAmerica::Error.error_message(404, {})
       end
 
       it 'must match 404 error message when code is 404' do
@@ -60,7 +60,7 @@ describe FundAmerica::Error do
 
     context '422 code' do
       before(:all) do
-        @response = FundAmerica::Error.error_message(422)
+        @response = FundAmerica::Error.error_message(422, {})
       end
 
       it 'must match 422 error message when code is 422' do
@@ -74,7 +74,7 @@ describe FundAmerica::Error do
 
     context '500 code' do
       before(:all) do
-        @response = FundAmerica::Error.error_message(500)
+        @response = FundAmerica::Error.error_message(500, {})
       end
 
       it 'must match 500 error message when code is 500' do
@@ -87,7 +87,7 @@ describe FundAmerica::Error do
     end
 
     it 'must match other error message when code is 123' do
-      response = FundAmerica::Error.error_message(123)
+      response = FundAmerica::Error.error_message(123, {})
       expect(response).to eq(@message_other)
     end
   end

--- a/spec/fund_america/escrow_service_application_spec.rb
+++ b/spec/fund_america/escrow_service_application_spec.rb
@@ -81,7 +81,13 @@ describe FundAmerica::EscrowServiceApplication do
       }
       @offering = FundAmerica::Offering.create(offering_options)
       @escrow_agreement = FundAmerica::EscrowAgreement.create({:offering_id => @offering['id']})
-
+      @signature = FundAmerica::ElectronicSignature.update(
+        @escrow_agreement['electronic_signatures'].first['id'],
+        :user_agent => 'FA Specs',
+        :ip_address => '127.0.0.1',
+        :literal => 'Test Signer',
+        :name => 'Test Signer',
+      )
       esa_options = {
         :offering_id => @offering['id'],
         :escrow_agreement_id => @escrow_agreement['id'],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'fund_america'
 
+FundAmerica.api_key = ENV['FUND_AMERICA_SANDBOX_KEY']
+
 RSpec::Matchers.define :be_boolean do
   match do |actual|
     actual == true || actual == false


### PR DESCRIPTION
This PR primarily makes it possible to run the tests _without_ editing the code (specifying the API key for tests via an environment variable) and documents how to run the tests.

Additionally it makes all the tests pass<sup>[*](#versioning)</sup>.

And adds the 422 response body to the 422 error message which made it possible to know what many of the errors were.

<a name="versioning">*</a> FA's date based API versioning makes it hard to say if these changes are more generally correct. My API version is `2016-04-13 22:40:42 UTC` which is clearly just when I signed up. FA supports pinning which is generally the best practice for a gem such as this but FA doesn't provide any way to discover the actual latest version that this gem should pin to.
