### PR TITLE
Entity platform investor

### DIFF
--- a/lib/fund_america/entity.rb
+++ b/lib/fund_america/entity.rb
@@ -119,6 +119,14 @@ module FundAmerica
         API::request(:get, "entities/#{entity_id}/investor_accreditation")
       end
 
+      # https://apps.fundamerica.com/api/entities/:id/platform_investor (GET)
+      # Usage: FundAmerica::Entity.platform_investor 
+      # Output: Returns entity specific platform_investor information
+      # Note: FA platform investor information will also be included with investor information
+      def platform_investor(entity_id )
+        API::request(:get, "entities/#{entity_id}/platform_investor")
+      end
+
     end
   end
 end


### PR DESCRIPTION
Adds entity platform_investor (GET).
Note: FA says they will be merging platform_investor information to exist within investor information in the future, this endpoint will remain and be backwards compatible . 
